### PR TITLE
Fix anchor URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # 🌐 SubTrace
 
   <p>
-    <a align="center"href="" target="https://github.com/SkyH34D/SubTrace">
+    <a align="center" href="https://github.com/SkyH34D/SubTrace" target="_blank">
       <img
         width="50%"
         src="https://github.com/SkyH34D/SubTrace/blob/a496eb9bf470966f5fd67c2b740e65d09102cd32/media/SubTrace.png"


### PR DESCRIPTION
## Summary
- fix the README image's GitHub link

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852abda5e18832bb414a578192bc18a